### PR TITLE
update to max-sdk-base, support building for arm64 (apple silicon)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ log.txt
 externals
 support
 build
+build-*
 *.o
 *.dylib
 tmp

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
-[submodule "source/max-api"]
-	path = source/max-api
-	url = https://github.com/Cycling74/max-api
 [submodule "source/libs/libsamplerate"]
 	path = source/libs/libsamplerate
 	url = https://github.com/libsndfile/libsamplerate
+[submodule "source/max-sdk-base"]
+	path = source/max-sdk-base
+	url = https://github.com/Cycling74/max-sdk-base

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.0)
 
-# Fetch the correct verion of the max-api
+# Fetch the correct verion of the max-sdk-base
 message(STATUS "Updating Git Submodules")
 execute_process(
 	COMMAND				git submodule update --init --recursive
@@ -9,7 +9,7 @@ execute_process(
 
 
 # Misc setup and subroutines
-include(${CMAKE_CURRENT_SOURCE_DIR}/source/max-api/script/max-package.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/source/max-sdk-base/script/max-package.cmake)
 
 
 # Generate a project for every folder in the "source/projects" folder

--- a/source/projects/vb.mi.brds_tilde/CMakeLists.txt
+++ b/source/projects/vb.mi.brds_tilde/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
 
 # paths to our sources
 set(MUTABLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../mutableSources32")
@@ -80,4 +80,4 @@ else()
 endif()
 
         
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)

--- a/source/projects/vb.mi.brds_tilde/vb.mi.brds_tilde.cpp
+++ b/source/projects/vb.mi.brds_tilde/vb.mi.brds_tilde.cpp
@@ -67,6 +67,8 @@ const uint16_t bit_reduction_masks[] = {
     0xffff };
 
 
+using std::clamp;
+
 using namespace c74::max;
 
 static t_class* this_class = nullptr;

--- a/source/projects/vb.mi.clds_tilde/CMakeLists.txt
+++ b/source/projects/vb.mi.clds_tilde/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
 
 # paths to our sources
 set(MUTABLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../mutableSources32")
@@ -85,4 +85,4 @@ if(APPLE)
 target_link_libraries(${PROJECT_NAME} PUBLIC "-framework Accelerate")
 endif()
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)

--- a/source/projects/vb.mi.clds_tilde/vb.mi.clds_tilde.cpp
+++ b/source/projects/vb.mi.clds_tilde/vb.mi.clds_tilde.cpp
@@ -49,7 +49,7 @@
 
 const uint16_t kAudioBlockSize = 32;        // sig vs can't be smaller than this!
 
-
+using std::clamp;
 
 using namespace c74::max;
 

--- a/source/projects/vb.mi.elmnts_tilde/CMakeLists.txt
+++ b/source/projects/vb.mi.elmnts_tilde/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
 
 # paths to our sources
 set(MUTABLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../mutableSources64")
@@ -83,4 +83,4 @@ if(APPLE)
 target_link_libraries(${PROJECT_NAME} PUBLIC "-framework Accelerate")
 endif()
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)

--- a/source/projects/vb.mi.elmnts_tilde/vb.mi.elmnts_tilde.cpp
+++ b/source/projects/vb.mi.elmnts_tilde/vb.mi.elmnts_tilde.cpp
@@ -41,6 +41,8 @@
 #include "Accelerate/Accelerate.h"
 #endif
 
+using std::clamp;
+
 using namespace c74::max;
 
 const size_t kBlockSize = elements::kMaxBlockSize;

--- a/source/projects/vb.mi.grds_tilde/CMakeLists.txt
+++ b/source/projects/vb.mi.grds_tilde/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
 
 # paths to our sources
 set(MUTABLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../mutableSources32")
@@ -52,4 +52,4 @@ target_compile_definitions(${PROJECT_NAME} PUBLIC TEST)
 source_group(TREE ${MUTABLE_PATH} FILES ${MI_SOURCES} ${AVRLIB_SOURCES})
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)

--- a/source/projects/vb.mi.grds_tilde/vb.mi.grds_tilde.cpp
+++ b/source/projects/vb.mi.grds_tilde/vb.mi.grds_tilde.cpp
@@ -45,6 +45,10 @@
 
 using namespace c74::max;
 
+double clamp(double input, double low, double high) {
+    return fmin(fmax(input, low), high);
+}
+
 #define COUNTMAX 4
 
 static t_class* this_class = nullptr;

--- a/source/projects/vb.mi.mrbls_tilde/CMakeLists.txt
+++ b/source/projects/vb.mi.mrbls_tilde/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.13)
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
 
 # paths to our sources
 set(MUTABLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../mutableSources32")
@@ -85,4 +85,4 @@ if(APPLE)
 target_link_libraries(${PROJECT_NAME} PUBLIC "-framework Accelerate")
 endif()
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)

--- a/source/projects/vb.mi.mrbls_tilde/vb.mi.mrbls_tilde.cpp
+++ b/source/projects/vb.mi.mrbls_tilde/vb.mi.mrbls_tilde.cpp
@@ -61,6 +61,7 @@
 
 #define MAX_NOTE_SIZE 256
 
+using std::clamp;
 
 using namespace c74::max;
 using namespace marbles;

--- a/source/projects/vb.mi.mu_tilde/CMakeLists.txt
+++ b/source/projects/vb.mi.mu_tilde/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
 
 
 include_directories( 
@@ -16,4 +16,4 @@ add_library(
 )
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)

--- a/source/projects/vb.mi.omi_tilde/CMakeLists.txt
+++ b/source/projects/vb.mi.omi_tilde/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
 
 set(MUTABLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../mutableSources64")
 set(STMLIB_PATH ${MUTABLE_PATH}/stmlib)
@@ -45,4 +45,4 @@ if(APPLE)
 target_link_libraries(${PROJECT_NAME} PUBLIC "-framework Accelerate")
 endif()
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)

--- a/source/projects/vb.mi.omi_tilde/vb.mi.omi_tilde.cpp
+++ b/source/projects/vb.mi.omi_tilde/vb.mi.omi_tilde.cpp
@@ -39,6 +39,8 @@
 #include "Accelerate/Accelerate.h"
 #endif
 
+using std::clamp;
+
 using namespace c74::max;
 
 

--- a/source/projects/vb.mi.plts_tilde/CMakeLists.txt
+++ b/source/projects/vb.mi.plts_tilde/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
 
 # paths to our sources
 set(MUTABLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../mutableSources64")
@@ -143,4 +143,4 @@ target_link_libraries(${PROJECT_NAME} PUBLIC "-framework Accelerate")
 endif()
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)

--- a/source/projects/vb.mi.plts_tilde/vb.mi.plts_tilde.cpp
+++ b/source/projects/vb.mi.plts_tilde/vb.mi.plts_tilde.cpp
@@ -42,6 +42,8 @@
 //#define ENABLE_LFO_MODE
 #pragma warning (disable : 4068 )
 
+using std::clamp;
+
 using namespace c74::max;
 
 

--- a/source/projects/vb.mi.pvoc_tilde/CMakeLists.txt
+++ b/source/projects/vb.mi.pvoc_tilde/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
 
 # paths to our sources
 set(MUTABLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../mutableSources32")
@@ -76,4 +76,4 @@ target_compile_definitions(${PROJECT_NAME} PUBLIC TEST)
 source_group(TREE ${MUTABLE_PATH} FILES ${MI_SOURCES} ${STMLIB_SOURCES})
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)

--- a/source/projects/vb.mi.pvoc_tilde/vb.mi.pvoc_tilde.cpp
+++ b/source/projects/vb.mi.pvoc_tilde/vb.mi.pvoc_tilde.cpp
@@ -49,6 +49,8 @@
 const uint16_t kBlockSize = 32;        // sig vs can't be smaller than this!
 
 
+using std::clamp;
+
 using namespace c74::max;
 
 

--- a/source/projects/vb.mi.reson_tilde/CMakeLists.txt
+++ b/source/projects/vb.mi.reson_tilde/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
 
 # paths to our sources
 set(MUTABLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../mutableSources64")
@@ -63,4 +63,4 @@ source_group(TREE ${MUTABLE_PATH} FILES ${STMLIB_SOURCES} ${MI_SOURCES})
 
 target_link_libraries(${PROJECT_NAME} PUBLIC "-framework Accelerate")
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)

--- a/source/projects/vb.mi.reson_tilde/vb.mi.reson_tilde.cpp
+++ b/source/projects/vb.mi.reson_tilde/vb.mi.reson_tilde.cpp
@@ -40,6 +40,8 @@
 // TODO: make kNumModes settable
 
 
+using std::clamp;
+
 using namespace c74::max;
 
 

--- a/source/projects/vb.mi.rngs_tilde/CMakeLists.txt
+++ b/source/projects/vb.mi.rngs_tilde/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
 
 # paths to our sources
 set(MUTABLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../mutableSources64")
@@ -88,4 +88,4 @@ if(APPLE)
 target_link_libraries(${PROJECT_NAME} PUBLIC "-framework Accelerate")
 endif()
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)

--- a/source/projects/vb.mi.rngs_tilde/vb.mi.rngs_tilde.cpp
+++ b/source/projects/vb.mi.rngs_tilde/vb.mi.rngs_tilde.cpp
@@ -42,6 +42,8 @@
 #include "Accelerate/Accelerate.h"
 #endif
 
+using std::clamp;
+
 using namespace c74::max;
 
 

--- a/source/projects/vb.mi.rppls_tilde/CMakeLists.txt
+++ b/source/projects/vb.mi.rppls_tilde/CMakeLists.txt
@@ -1,5 +1,17 @@
 cmake_minimum_required(VERSION 3.0)
 
+set(SKIP_RPPLS FALSE)
+if (APPLE)
+    if (NOT CMAKE_OSX_ARCHITECTURES)
+        set(CMAKE_OSX_ARCHITECTURES x86_64)
+    endif()
+    if (CMAKE_OSX_ARCHITECTURES MATCHES "arm64")
+		set(SKIP_RPPLS TRUE)
+		message("skipping rppls")
+	endif()
+endif()
+
+if(NOT SKIP_RPPLS)
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
 
@@ -46,3 +58,5 @@ source_group(TREE ${VCV_PATH} FILES ${VCV_SOURCES})
 
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)
+
+endif()

--- a/source/projects/vb.mi.rppls_tilde/CMakeLists.txt
+++ b/source/projects/vb.mi.rppls_tilde/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
 
 # paths to our sources
 set(MUTABLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../mutableSources32")
@@ -45,4 +45,4 @@ source_group(TREE ${VCV_PATH} FILES ${VCV_SOURCES})
 #target_link_libraries(${PROJECT_NAME} PUBLIC "-framework Accelerate")
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)

--- a/source/projects/vb.mi.rppls_tilde/vb.mi.rppls_tilde.cpp
+++ b/source/projects/vb.mi.rppls_tilde/vb.mi.rppls_tilde.cpp
@@ -34,6 +34,7 @@
 // needs further optimization...
 
 
+using std::clamp;
 
 using namespace c74::max;
 

--- a/source/projects/vb.mi.sheep_tilde/CMakeLists.txt
+++ b/source/projects/vb.mi.sheep_tilde/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
 
 # paths to our sources
 set(MUTABLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../mutableSources32")
@@ -51,4 +51,4 @@ target_compile_definitions(${PROJECT_NAME} PUBLIC TEST)
 source_group(TREE ${MUTABLE_PATH} FILES ${MI_SOURCES} ${STMLIB_SOURCES})
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)

--- a/source/projects/vb.mi.tds.osc_tilde/CMakeLists.txt
+++ b/source/projects/vb.mi.tds.osc_tilde/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
 
 # paths to our sources
 set(MUTABLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../mutableSources32")
@@ -43,4 +43,4 @@ target_compile_definitions(${PROJECT_NAME} PUBLIC TEST)
 source_group(TREE ${MI_PATH} FILES ${MI_SOURCES})
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)

--- a/source/projects/vb.mi.tds1_tilde/CMakeLists.txt
+++ b/source/projects/vb.mi.tds1_tilde/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
 
 # paths to our sources
 set(MUTABLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../mutableSources32")
@@ -54,4 +54,4 @@ target_compile_definitions(${PROJECT_NAME} PUBLIC TEST)
 source_group(TREE ${MUTABLE_PATH} FILES ${MI_SOURCES} ${STMLIB_SOURCES})
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)

--- a/source/projects/vb.mi.tds_tilde/CMakeLists.txt
+++ b/source/projects/vb.mi.tds_tilde/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
 
 # paths to our sources
 set(MUTABLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../mutableSources32")
@@ -56,4 +56,4 @@ target_compile_definitions(${PROJECT_NAME} PUBLIC TEST)
 source_group(TREE ${MUTABLE_PATH} FILES ${MI_SOURCES} ${STMLIB_SOURCES})
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)

--- a/source/projects/vb.mi.twobumps_tilde/CMakeLists.txt
+++ b/source/projects/vb.mi.twobumps_tilde/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
 
 # paths to our sources
 set(MUTABLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../parasites")
@@ -53,4 +53,4 @@ target_compile_definitions(${PROJECT_NAME} PUBLIC TEST)
 source_group(TREE ${MUTABLE_PATH} FILES ${MI_SOURCES} ${STMLIB_SOURCES})
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)

--- a/source/projects/vb.mi.twodrunks_tilde/CMakeLists.txt
+++ b/source/projects/vb.mi.twodrunks_tilde/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
 
 # paths to our sources
 set(MUTABLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../parasites")
@@ -53,4 +53,4 @@ target_compile_definitions(${PROJECT_NAME} PUBLIC TEST)
 source_group(TREE ${MUTABLE_PATH} FILES ${MI_SOURCES} ${STMLIB_SOURCES})
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)

--- a/source/projects/vb.mi.verb_tilde/CMakeLists.txt
+++ b/source/projects/vb.mi.verb_tilde/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
 
 # paths to our sources
 set(MUTABLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../mutableSources64")
@@ -44,4 +44,4 @@ target_compile_definitions(${PROJECT_NAME} PUBLIC TEST)
 source_group(TREE ${MUTABLE_PATH} FILES ${STMLIB_SOURCES})
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)

--- a/source/projects/vb.mi.verb_tilde/vb.mi.verb_tilde.cpp
+++ b/source/projects/vb.mi.verb_tilde/vb.mi.verb_tilde.cpp
@@ -33,6 +33,8 @@
 #include "c74_msp.h"
 #include "reverb.h"
 
+using std::clamp;
+
 using namespace c74::max;
 
 

--- a/source/projects/vb.mi.wrps_tilde/CMakeLists.txt
+++ b/source/projects/vb.mi.wrps_tilde/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.0)
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-pretarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-pretarget.cmake)
 
 # paths to our sources
 set(MUTABLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../mutableSources32")
@@ -66,4 +66,4 @@ target_compile_definitions(${PROJECT_NAME} PUBLIC TEST)
 source_group(TREE ${MUTABLE_PATH} FILES ${STMLIB_SOURCES} ${MI_SOURCES})
 
 
-include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-api/script/max-posttarget.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../max-sdk-base/script/max-posttarget.cmake)

--- a/source/projects/vb.mi.wrps_tilde/vb.mi.wrps_tilde.cpp
+++ b/source/projects/vb.mi.wrps_tilde/vb.mi.wrps_tilde.cpp
@@ -38,6 +38,7 @@
 #include "read_inputs.hpp"
 
 
+using std::clamp;
 
 using namespace c74::max;
 


### PR DESCRIPTION
Fairly simple and painless updates to support building Fat externals for apple silicon.

The one issue is with the vb.mi.rppls~ external which requires some updates to replace simd usage with Neon. the cmake script for this project is updated to exclude if building apple-arm64